### PR TITLE
Endpoint and CDN Specification

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -5,10 +5,11 @@
 @interface SEGHTTPClient : NSObject
 
 @property (nonatomic, strong) SEGRequestFactory requestFactory;
+@property (nonatomic, copy, readwrite) NSString *endpoint;
 
 + (SEGRequestFactory)defaultRequestFactory;
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory;
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory endpoint:(NSString *)endpoint;
 
 /**
  * Upload dictionary formatted as per https://segment.com/docs/sources/server/http/#batch.

--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -5,11 +5,11 @@
 @interface SEGHTTPClient : NSObject
 
 @property (nonatomic, strong) SEGRequestFactory requestFactory;
-@property (nonatomic, copy, readwrite) NSString *endpoint;
+@property (nonatomic, copy, readwrite) NSString *host;
 
 + (SEGRequestFactory)defaultRequestFactory;
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory endpoint:(NSString *)endpoint;
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory host:(NSString *)host;
 
 /**
  * Upload dictionary formatted as per https://segment.com/docs/sources/server/http/#batch.

--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -19,7 +19,7 @@
  */
 - (NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler;
 
-- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, NSDictionary *settings))completionHandler;
+- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey cdn:(NSString *)cdn completionHandler:(void (^)(BOOL success, NSDictionary *settings))completionHandler;
 
 - (NSURLSessionDataTask *)attributionWithWriteKey:(NSString *)writeKey forDevice:(NSDictionary *)context completionHandler:(void (^)(BOOL success, NSDictionary *properties))completionHandler;
 

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -11,7 +11,7 @@
     };
 }
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory endpoint:(NSString *)endpoint
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory host:(NSString *)host
 {
     if (self = [self init]) {
         if (requestFactory == nil) {
@@ -19,7 +19,7 @@
         } else {
             self.requestFactory = requestFactory;
         }
-        self.endpoint = endpoint;
+        self.host = host;
     }
     return self;
 }
@@ -42,7 +42,7 @@
     };
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 
-    NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/batch", self.endpoint];
+    NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/batch", self.host];
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"POST"];
@@ -105,7 +105,7 @@
     };
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 
-    NSString *rawURL = [NSString stringWithFormat:@"https://%2$@/v1/projects/%1$@/settings", writeKey, cdn];
+    NSString *rawURL = [NSString stringWithFormat:@"http://%2$@/v1/projects/%1$@/settings", writeKey, cdn];
     NSURL *url = [NSURL URLWithString:rawURL];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"GET"];

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -2,7 +2,6 @@
 #import "NSData+SEGGZIP.h"
 #import "SEGAnalyticsUtils.h"
 
-
 @implementation SEGHTTPClient
 
 + (NSMutableURLRequest * (^)(NSURL *))defaultRequestFactory
@@ -12,7 +11,7 @@
     };
 }
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory
+- (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory endpoint:(NSString *)endpoint
 {
     if (self = [self init]) {
         if (requestFactory == nil) {
@@ -20,6 +19,7 @@
         } else {
             self.requestFactory = requestFactory;
         }
+        self.endpoint = endpoint;
     }
     return self;
 }
@@ -42,7 +42,8 @@
     };
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 
-    NSURL *url = [NSURL URLWithString:@"https://api.astronomer.io/v1/batch"];
+    NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/batch", self.endpoint];
+    NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"POST"];
 

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -99,7 +99,7 @@
     return task;
 }
 
-- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, NSDictionary *settings))completionHandler
+- (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey cdn:(NSString *)cdn completionHandler:(void (^)(BOOL success, NSDictionary *settings))completionHandler
 {
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     config.HTTPAdditionalHeaders = @{
@@ -107,7 +107,7 @@
     };
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 
-    NSString *rawURL = [NSString stringWithFormat:@"https://cdn.astronomer.io/v1/projects/%@/settings", writeKey];
+    NSString *rawURL = [NSString stringWithFormat:@"https://%2$@/v1/projects/%1$@/settings", writeKey, cdn];
     NSURL *url = [NSURL URLWithString:rawURL];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"GET"];

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -20,7 +20,6 @@
             self.requestFactory = requestFactory;
         }
         self.endpoint = endpoint;
-        NSLog(@"Initialized client with endpoint: %@", self.endpoint);
     }
     return self;
 }
@@ -44,7 +43,6 @@
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 
     NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/batch", self.endpoint];
-    NSLog(@"batch: %@", urlString);
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"POST"];

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -20,6 +20,7 @@
             self.requestFactory = requestFactory;
         }
         self.endpoint = endpoint;
+        NSLog(@"Initialized client with endpoint: %@", self.endpoint);
     }
     return self;
 }
@@ -43,6 +44,7 @@
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
 
     NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/batch", self.endpoint];
+    NSLog(@"batch: %@", urlString);
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"POST"];

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -94,6 +94,7 @@ static BOOL GetAdTrackingEnabled()
         self.configuration = analytics.configuration;
         self.httpClient = analytics.httpClient;
         NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/import", self.configuration.endpoint];
+        NSLog(@"import: %@", urlString);
         self.apiURL = [NSURL URLWithString:urlString];
         self.userId = [self getUserId];
         self.reachability = [SEGReachability reachabilityWithHostname:@"google.com"];

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -93,7 +93,7 @@ static BOOL GetAdTrackingEnabled()
         self.analytics = analytics;
         self.configuration = analytics.configuration;
         self.httpClient = analytics.httpClient;
-        NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/import", self.configuration.endpoint];
+        NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/import", self.configuration.host];
         self.apiURL = [NSURL URLWithString:urlString];
         self.userId = [self getUserId];
         self.reachability = [SEGReachability reachabilityWithHostname:@"google.com"];

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -93,7 +93,8 @@ static BOOL GetAdTrackingEnabled()
         self.analytics = analytics;
         self.configuration = analytics.configuration;
         self.httpClient = analytics.httpClient;
-        self.apiURL = [NSURL URLWithString:@"https://api.astronomer.io/v1/import"];
+        NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/import", self.configuration.endpoint];
+        self.apiURL = [NSURL URLWithString:urlString];
         self.userId = [self getUserId];
         self.reachability = [SEGReachability reachabilityWithHostname:@"google.com"];
         [self.reachability startNotifier];

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -94,7 +94,6 @@ static BOOL GetAdTrackingEnabled()
         self.configuration = analytics.configuration;
         self.httpClient = analytics.httpClient;
         NSString *urlString = [NSString stringWithFormat:@"https://%@/v1/import", self.configuration.endpoint];
-        NSLog(@"import: %@", urlString);
         self.apiURL = [NSURL URLWithString:urlString];
         self.userId = [self getUserId];
         self.reachability = [SEGReachability reachabilityWithHostname:@"google.com"];

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -17,11 +17,11 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 @interface SEGAnalyticsConfiguration : NSObject
 
 /**
- * Creates and returns a configuration with default settings and the given write key.
+ * Creates and returns a configuration with default settings, the given write key, and endpoint.
  *
  * @param writeKey Your project's write key from segment.io.
  */
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey;
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey :(NSString *)endpoint;
 
 /**
  * Your project's write key from segment.io.
@@ -29,6 +29,13 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
  * @see +configurationWithWriteKey:
  */
 @property (nonatomic, copy, readonly) NSString *writeKey;
+
+/**
+ * Your project's endpoint for API calls.
+ *
+ * @see +configurationWithWriteKey:
+ */
+@property (nonatomic, copy, readonly) NSString *endpoint;
 
 /**
  * Whether the analytics client should use location services.
@@ -322,7 +329,7 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 @interface SEGAnalytics (Deprecated)
 
 + (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
-- (instancetype)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *)endpoint __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -328,7 +328,7 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 
 @interface SEGAnalytics (Deprecated)
 
-+ (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
++ (void)initializeWithWriteKey:(NSString *)writeKey endpoint: (NSString *)endpoint __attribute__((deprecated("Use +setupWithConfiguration: instead")));
 - (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -17,13 +17,13 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 @interface SEGAnalyticsConfiguration : NSObject
 
 /**
- * Creates and returns a configuration with default settings, the given write key, and endpoint.
+ * Creates and returns a configuration with default settings, the given write key, and host.
  *
  * @param writeKey Your project's write key from segment.io.
  */
 + (instancetype)configurationWithWriteKey:(NSString *)writeKey;
 
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn;
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn;
 
 /**
  * Your project's write key from segment.io.
@@ -33,11 +33,11 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 @property (nonatomic, copy, readonly) NSString *writeKey;
 
 /**
- * Your project's endpoint for API calls.
+ * Your project's host for API calls.
  *
  * @see +configurationWithWriteKey:
  */
-@property (nonatomic, copy, readonly) NSString *endpoint;
+@property (nonatomic, copy, readonly) NSString *host;
 
 /**
  * Your project's cdn.
@@ -339,8 +339,8 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 
 + (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
 - (instancetype)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
-+ (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn __attribute__((deprecated("Use +setupWithConfiguration: instead")));
-- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn __attribute__((deprecated("Use -initWithConfiguration: instead")));
++ (void)initializeWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn __attribute__((deprecated("Use +setupWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -21,6 +21,8 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
  *
  * @param writeKey Your project's write key from segment.io.
  */
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey;
+
 + (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn;
 
 /**
@@ -335,6 +337,8 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 
 @interface SEGAnalytics (Deprecated)
 
++ (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
 + (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn __attribute__((deprecated("Use +setupWithConfiguration: instead")));
 - (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -21,7 +21,7 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
  *
  * @param writeKey Your project's write key from segment.io.
  */
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey :(NSString *)endpoint;
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint;
 
 /**
  * Your project's write key from segment.io.
@@ -329,7 +329,7 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 @interface SEGAnalytics (Deprecated)
 
 + (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
-- (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *)endpoint __attribute__((deprecated("Use -initWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -21,7 +21,7 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
  *
  * @param writeKey Your project's write key from segment.io.
  */
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint;
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn;
 
 /**
  * Your project's write key from segment.io.
@@ -36,6 +36,13 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
  * @see +configurationWithWriteKey:
  */
 @property (nonatomic, copy, readonly) NSString *endpoint;
+
+/**
+ * Your project's cdn.
+ *
+ * @see +configurationWithWriteKey:
+ */
+@property (nonatomic, copy, readonly) NSString *cdn;
 
 /**
  * Whether the analytics client should use location services.
@@ -328,8 +335,8 @@ typedef NSMutableURLRequest * (^SEGRequestFactory)(NSURL *);
 
 @interface SEGAnalytics (Deprecated)
 
-+ (void)initializeWithWriteKey:(NSString *)writeKey endpoint: (NSString *)endpoint __attribute__((deprecated("Use +setupWithConfiguration: instead")));
-- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint __attribute__((deprecated("Use -initWithConfiguration: instead")));
++ (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn __attribute__((deprecated("Use +setupWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -119,7 +119,7 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.storage = [[SEGFileStorage alloc] initWithFolder:[SEGFileStorage applicationSupportDirectoryURL] crypto:configuration.crypto];
 #endif
         self.cachedAnonymousId = [self loadOrGenerateAnonymousID:NO];
-        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory];
+        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory endpoint:configuration.endpoint];
 
         // Update settings on each integration immediately
         [self refreshSettings];

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -21,7 +21,7 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 @interface SEGAnalyticsConfiguration ()
 
 @property (nonatomic, copy, readwrite) NSString *writeKey;
-@property (nonatomic, copy, readwrite) NSString *endpoint;
+@property (nonatomic, copy, readwrite) NSString *host;
 @property (nonatomic, copy, readwrite) NSString *cdn;
 @property (nonatomic, strong, readonly) NSMutableArray *factories;
 
@@ -32,19 +32,19 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 
 + (instancetype)configurationWithWriteKey:(NSString *)writeKey
 {
-    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:nil cdn:nil];
+    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey host:nil cdn:nil];
 }
 
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn
 {
-    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:endpoint cdn:cdn];
+    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey host:host cdn:cdn];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
+- (instancetype)initWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
-        self.endpoint = (endpoint) ? endpoint : @"api.astronomer.io";
+        self.host = (host) ? host : @"api.astronomer.io";
         self.cdn = (cdn) ? cdn : @"cdn.astronomer.io";
     }
     return self;
@@ -126,7 +126,7 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.storage = [[SEGFileStorage alloc] initWithFolder:[SEGFileStorage applicationSupportDirectoryURL] crypto:configuration.crypto];
 #endif
         self.cachedAnonymousId = [self loadOrGenerateAnonymousID:NO];
-        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory endpoint:configuration.endpoint];
+        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory host:configuration.host];
 
         // Update settings on each integration immediately
         [self refreshSettings];
@@ -747,22 +747,22 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
 + (void)initializeWithWriteKey:(NSString *)writeKey
 {
-    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:nil cdn:nil]];
+    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey host:nil cdn:nil]];
 }
 
 - (instancetype)initWithWriteKey:(NSString *)writeKey
 {
-    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:nil cdn:nil]];
+    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey host:nil cdn:nil]];
 }
 
-+ (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
++ (void)initializeWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn
 {
-    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint cdn:cdn]];
+    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey host:host cdn:cdn]];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
+- (instancetype)initWithWriteKey:(NSString *)writeKey host:(NSString *)host cdn:(NSString *)cdn
 {
-    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint cdn:cdn]];
+    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey host:host cdn:cdn]];
 }
 
 - (void)registerPushDeviceToken:(NSData *)deviceToken

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -21,6 +21,7 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 @interface SEGAnalyticsConfiguration ()
 
 @property (nonatomic, copy, readwrite) NSString *writeKey;
+@property (nonatomic, copy, readwrite) NSString *endpoint;
 @property (nonatomic, strong, readonly) NSMutableArray *factories;
 
 @end
@@ -28,15 +29,16 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 
 @implementation SEGAnalyticsConfiguration
 
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey :(NSString *)endpoint
 {
-    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey];
+    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey :endpoint];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey
+- (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *)endpoint
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
+        self.endpoint = endpoint;
     }
     return self;
 }
@@ -736,14 +738,14 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
-+ (void)initializeWithWriteKey:(NSString *)writeKey
++ (void)initializeWithWriteKey:(NSString *)writeKey :(NSString *)endpoint
 {
-    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
+    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey:endpoint]];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey
+- (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *) endpoint
 {
-    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
+    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey:endpoint]];
 }
 
 - (void)registerPushDeviceToken:(NSData *)deviceToken

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -30,6 +30,11 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 
 @implementation SEGAnalyticsConfiguration
 
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey
+{
+    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:nil cdn:nil];
+}
+
 + (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
 {
     return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:endpoint cdn:cdn];
@@ -39,8 +44,9 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
-        self.endpoint = endpoint;
-        self.cdn = cdn;
+        self.endpoint = (endpoint) ? endpoint : @"api.astronomer.io";
+        self.cdn = (cdn) ? cdn : @"cdn.astronomer.io";
+        NSLog(@"Endpoint: %1$@ CDN: %2$@", self.endpoint, self.cdn);
     }
     return self;
 }
@@ -739,6 +745,16 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
++ (void)initializeWithWriteKey:(NSString *)writeKey
+{
+    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:nil cdn:nil]];
+}
+
+- (instancetype)initWithWriteKey:(NSString *)writeKey
+{
+    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:nil cdn:nil]];
+}
 
 + (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
 {

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -46,7 +46,6 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.writeKey = writeKey;
         self.endpoint = (endpoint) ? endpoint : @"api.astronomer.io";
         self.cdn = (cdn) ? cdn : @"cdn.astronomer.io";
-        NSLog(@"Endpoint: %1$@ CDN: %2$@", self.endpoint, self.cdn);
     }
     return self;
 }

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -41,7 +41,6 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.writeKey = writeKey;
         self.endpoint = endpoint;
         self.cdn = cdn;
-        NSLog(@"Initializing Configuration with endpoint: %@", self.endpoint);
     }
     return self;
 }

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -29,12 +29,12 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 
 @implementation SEGAnalyticsConfiguration
 
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey :(NSString *)endpoint
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
 {
-    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey :endpoint];
+    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:endpoint];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *)endpoint
+- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
@@ -738,14 +738,14 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
-+ (void)initializeWithWriteKey:(NSString *)writeKey :(NSString *)endpoint
++ (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
 {
-    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey:endpoint]];
+    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint]];
 }
 
 - (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *) endpoint
 {
-    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey:endpoint]];
+    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint]];
 }
 
 - (void)registerPushDeviceToken:(NSData *)deviceToken

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -743,7 +743,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint]];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey :(NSString *) endpoint
+- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
 {
     return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint]];
 }

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -22,6 +22,7 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 
 @property (nonatomic, copy, readwrite) NSString *writeKey;
 @property (nonatomic, copy, readwrite) NSString *endpoint;
+@property (nonatomic, copy, readwrite) NSString *cdn;
 @property (nonatomic, strong, readonly) NSMutableArray *factories;
 
 @end
@@ -29,16 +30,17 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
 
 @implementation SEGAnalyticsConfiguration
 
-+ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
++ (instancetype)configurationWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
 {
-    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:endpoint];
+    return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey endpoint:endpoint cdn:cdn];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
+- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
         self.endpoint = endpoint;
+        self.cdn = cdn;
         NSLog(@"Initializing Configuration with endpoint: %@", self.endpoint);
     }
     return self;
@@ -571,7 +573,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
         return;
     }
 
-    self.settingsRequest = [self.httpClient settingsForWriteKey:self.configuration.writeKey completionHandler:^(BOOL success, NSDictionary *settings) {
+    self.settingsRequest = [self.httpClient settingsForWriteKey:self.configuration.writeKey cdn:self.configuration.cdn completionHandler:^(BOOL success, NSDictionary *settings) {
         if (success) {
             [self setCachedSettings:settings];
         } else {
@@ -739,14 +741,14 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
-+ (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
++ (void)initializeWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
 {
-    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint]];
+    [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint cdn:cdn]];
 }
 
-- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint
+- (instancetype)initWithWriteKey:(NSString *)writeKey endpoint:(NSString *)endpoint cdn:(NSString *)cdn
 {
-    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint]];
+    return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey endpoint:endpoint cdn:cdn]];
 }
 
 - (void)registerPushDeviceToken:(NSData *)deviceToken

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -39,6 +39,7 @@ NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
     if (self = [self init]) {
         self.writeKey = writeKey;
         self.endpoint = endpoint;
+        NSLog(@"Initializing Configuration with endpoint: %@", self.endpoint);
     }
     return self;
 }

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
When using analytics-ios, you can now specify an endpoint and CDN. If these values are left out, we will just default to astronomer's API and CDN.

