### PR TITLE
Fix GitHub organization name

### DIFF
--- a/MetarouterAnalytics.podspec
+++ b/MetarouterAnalytics.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage         = "http://metarouter.io/"
   s.license          =  { :type => 'MIT' }
   s.author           = { "Astronomer" => "info@metarouter.io" }
-  s.source           = { :git => "https://github.com/metarouter/analytics-ios.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/metarouterio/analytics-ios.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/metarouter'
 
   s.ios.deployment_target = '10.0'

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Note: Metarouter _strongly_ recommends that you use a dynamic framework to manag
 ### Carthage
 
 ```
-github "metarouter/analytics-ios"
+github "metarouterio/analytics-ios"
 ```
 
 ### Swift Package Manager (SPM)
@@ -72,7 +72,7 @@ let package = Package(
         // Add a package containing Analytics as the name along with the git url
         .package(
             name: "Metarouter",
-            url: "git@github.com:metarouter/analytics-ios.git"
+            url: "git@github.com:metarouterio/analytics-ios.git"
         )
     ],
     targets: [


### PR DESCRIPTION
**What does this PR do?**
Fix GitHub organization name from `metarouter` to `metarouterio`
